### PR TITLE
feat: Add network selection for Mainnet and Devnet

### DIFF
--- a/src/handlers/blinks.ts
+++ b/src/handlers/blinks.ts
@@ -7,6 +7,7 @@ export async function handleBlinks(req: Request): Promise<Response> {
   const recipientWallet = pathParts[2];
   const amount = url.searchParams.get("amount") || "0.1";
   const memo = url.searchParams.get("memo") || "Payment";
+  const network = url.searchParams.get("network") || "mainnet-beta";
   
   const metadata: BlinksMetadata = {
     type: "action",
@@ -17,7 +18,7 @@ export async function handleBlinks(req: Request): Promise<Response> {
     links: {
       actions: [{
         label: `Send ${amount} SOL`,
-        href: `/api/transaction/${recipientWallet}/${amount}`,
+        href: `/api/transaction/${recipientWallet}/${amount}?network=${network}`,
       }],
     },
   };

--- a/src/handlers/transaction.ts
+++ b/src/handlers/transaction.ts
@@ -6,6 +6,7 @@ export async function handleTransaction(req: Request): Promise<Response> {
   const pathParts = url.pathname.split("/");
   const recipientWallet = pathParts[3];
   const amount = pathParts[4];
+  const network = url.searchParams.get("network") || "mainnet-beta";
   
   try {
     const body = await req.json();
@@ -18,7 +19,8 @@ export async function handleTransaction(req: Request): Promise<Response> {
     const base64Transaction = await createTransferTransaction(
       account,
       recipientWallet,
-      parseFloat(amount)
+      parseFloat(amount),
+      network
     );
 
     return new Response(

--- a/src/templates/home.html
+++ b/src/templates/home.html
@@ -72,6 +72,14 @@
             placeholder="e.g., Coffee payment"
           />
         </div>
+
+        <div class="form-group">
+          <label for="network">Network</label>
+          <select id="network" name="network" style="width: 100%; padding: 12px; border: 1px solid rgba(0, 255, 194, 0.15); background: rgba(11, 15, 18, 0.8); color: #EAFBF6; border-radius: 10px; font-size: 16px;">
+            <option value="mainnet-beta" selected>Production (Mainnet)</option>
+            <option value="devnet">Devnet</option>
+          </select>
+        </div>
         
         <div class="form-group">
           <label>QR Code Type</label>
@@ -113,11 +121,6 @@
         <button class="action-btn new-btn" onclick="resetForm()">
           New QR
         </button>
-      </div>
-      
-      <div class="warning-box">
-        <strong>Test Mode (Devnet)</strong><br>
-        Using test SOL only. Switch to mainnet for real payments.
       </div>
     </div>
   </div>

--- a/src/utils/solana.ts
+++ b/src/utils/solana.ts
@@ -8,12 +8,15 @@ import {
     LAMPORTS_PER_SOL
   } from "https://esm.sh/@solana/web3.js@1.87.6";
   
+  type SolanaCluster = "devnet" | "testnet" | "mainnet-beta";
+
   export async function createTransferTransaction(
     senderAddress: string,
     recipientAddress: string,
-    amountSOL: number
+    amountSOL: number,
+    network: string,
   ): Promise<string> {
-    const connection = new Connection(clusterApiUrl("devnet"));
+    const connection = new Connection(clusterApiUrl(network as SolanaCluster));
     const sender = new PublicKey(senderAddress);
     const recipient = new PublicKey(recipientAddress);
     

--- a/static/app.js
+++ b/static/app.js
@@ -71,6 +71,7 @@ document.addEventListener('DOMContentLoaded', function() {
       const wallet = document.getElementById('wallet').value;
       const amount = document.getElementById('amount').value;
       const memo = document.getElementById('memo').value || 'Payment';
+      const network = document.getElementById('network').value;
       
       localStorage.setItem('wallet_address', wallet);
       
@@ -82,7 +83,7 @@ document.addEventListener('DOMContentLoaded', function() {
       } else {
         // Phantom Universal Link
         const baseUrl = window.location.origin;
-        const targetUrl = `${baseUrl}/pay/${wallet}?amount=${amount}&memo=${encodeURIComponent(memo)}`;
+        const targetUrl = `${baseUrl}/pay/${wallet}?amount=${amount}&memo=${encodeURIComponent(memo)}&network=${network}`;
         paymentUrl = `https://phantom.app/ul/browse/${targetUrl}`;
       }
       


### PR DESCRIPTION
This commit introduces a network selection dropdown on the frontend, allowing users to choose between "Production (Mainnet)" and "Devnet".

Key changes:
- Added a network selector to the main page, with "Production (Mainnet)" as the default option.
- The selected network is now passed to the backend when generating transaction links.
- The backend now uses the provided network to connect to the appropriate Solana cluster (mainnet-beta or devnet).
- Removed the hardcoded "Test Mode (Devnet)" warning message.